### PR TITLE
Changing package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
     "description": "Prototype Express server for relaying information between mobile devices for the game Pac Macro.",
     "main": "dist/app.js",
     "scripts": {
-        "start": "tsc && node dist/app.js",
+        "start": "node dist/app.js",
+        "build": "tsc",
+        "postinstall":"npm run build",
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "repository": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "main": "dist/app.js",
     "scripts": {
         "start": "node dist/app.js",
-        "build": "tsc",
-        "postinstall":"npm run build",
+        "tsc": "tsc",
+        "postinstall":"npm run tsc",
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "repository": {


### PR DESCRIPTION
Here's the original 
```json
"scripts": {
        "start": "tsc && node dist/app.js",
        "test": "echo \"Error: no test specified\" && exit 1"
 },
```

Adding ```"tsc": "tsc"``` to call ```tsc``` from an npm script. Otherwise Heroku tries to find a global dependency named ```tsc```. 

```json
"scripts": {
        "start": "node dist/app.js",
        "tsc": "tsc",
        "postinstall":"npm run tsc",
        "test": "echo \"Error: no test specified\" && exit 1"
},
```

[See more info here](https://stackoverflow.com/questions/48972663/how-do-i-compile-typescript-at-heroku-postinstall)